### PR TITLE
Don't use free variables

### DIFF
--- a/general.el
+++ b/general.el
@@ -90,9 +90,10 @@ function, positional arguments are required. PREFIX corresponds to a prefix
 sequence of any length. KEYMAP determines the keymap to bind the MAPS in."
   (declare (indent defun))
   (setq maps (general--apply-prefix prefix maps))
-  (while (setq key (pop maps)
-               func (pop maps))
-    (define-key keymap key func)))
+  (let (key func)
+    (while (setq key (pop maps)
+                 func (pop maps))
+      (define-key keymap key func))))
 
 ;; can't apply evil-define-key since it is a macro
 ;; either need to use eval or splice (,@) with defmacro
@@ -118,9 +119,10 @@ keybindings in. KEYMAP determines the keymap to bind the MAPS in."
   (setq maps (general--apply-prefix prefix maps))
   ;; emacs 24.4 dependency
   (with-eval-after-load 'evil
-    (while (setq key (pop maps)
-                 func (pop maps))
-      (evil-define-key state keymap key func))))
+    (let (key func)
+      (while (setq key (pop maps)
+                   func (pop maps))
+        (evil-define-key state keymap key func)))))
 
 ;;; Functions With Keyword Arguments
 ;; TODO does autoload recognize cl-defun?


### PR DESCRIPTION
Use local variables instead of them. This also fixes following byte-compile warnings.

```
In general--emacs-define-key:                                                     
general.el:95:24:Warning: assignment to free variable `key'
general.el:95:28:Warning: assignment to free variable `func'
general.el:95:17:Warning: reference to free variable `key'
general.el:95:17:Warning: reference to free variable `func'

In general--evil-define-key:
general.el:123:37:Warning: assignment to free variable `key'
general.el:123:41:Warning: assignment to free variable `func' 
```