### PR TITLE
Force events to be added in general-simulate-keys

### DIFF
--- a/general.el
+++ b/general.el
@@ -662,7 +662,9 @@ should not be quoted."
        (let ((keys (kbd ,keys))
              (command ,command))
          (setq prefix-arg current-prefix-arg)
-         (setq unread-command-events (listify-key-sequence keys))
+         (setq unread-command-events
+               (mapcar (lambda (ev) (cons t ev))
+                       (listify-key-sequence keys)))
          (when command
            (let ((this-command command))
              (call-interactively command)))))))


### PR DESCRIPTION
This seems to be required for the following to work, atleast for me.
```el
(use-package projectile
  :general
  (:keymaps 'projectile-mode-map
            "p" (list (general-simulate-keys "C-c p") :which-key "projectile"))
  ...)
```

Without this patch, the keys are simulated but which-key is showing the bindings for `C-c`. Looking at [which-key-reload-key-sequence](https://github.com/justbur/emacs-which-key/blob/a6a9f352e735f3d7faf45d0e8f23f3a346c04f9c/which-key.el#L1778-L1785), it seems to be the right way.