### PR TITLE
Use emacs batch in compile rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 	cask exec buttercup -L .
 
 compile:
-	cask exec emacs -Q --eval '(byte-compile-file "general.el")'
+	cask exec emacs -batch -Q --eval '(byte-compile-file "general.el")'
 
 clean:
 	rm -f *.elc


### PR DESCRIPTION
Prevent emacs from popping up when compiling.