### PR TITLE
Add more control over autoloads

### DIFF
--- a/README.org
+++ b/README.org
@@ -1010,8 +1010,7 @@ One annoyance you may encounter is that the default function for indentation wil
 This is an annoyance you may have using other emacs packages as well and can be fixed by modifying =lisp-indent-function= (see [[http://emacs.stackexchange.com/q/10230/5278][this emacs stackexchange question]] and Fuco1's modified ~lisp-indent-function~ in one of the answers there).
 
 *** :no-autoload Keyword
-
-If generating autoloads for commands is not desirable, it can be disabled globally (with the ~general-use-package-emit-autoloads~ option), on a per-binding, or on a per-form basis. To skip generating autoloads for a command, use the extended command definition and set the =:no-autoload= option to non-nil. This can be particularly handy when binding to functions defined in the same use-package block, otherwise the byte-compiler complains about multiple definitions of the same function:
+If generating autoloads for commands is not desirable, it can be disabled globally (with the =general-use-package-emit-autoloads= option), on a per-binding, or on a per-form basis. To skip generating autoloads for a command, use the extended command definition and set the =:no-autoload= option to non-nil. This can be particularly handy when binding to functions defined in the same use-package block, otherwise the byte-compiler complains about multiple definitions of the same function:
 #+begin_src emacs-lisp
 (use-package org
   :general

--- a/README.org
+++ b/README.org
@@ -982,7 +982,7 @@ These both use ~general-add-hook~ to create "transient" hooks.
 * Integration with Other Packages
 ** Use-package Keywords
 *** :general Keyword
-General also optionally provides a use-package keyword. =:general= is similar to =:bind= in that it implies =:defer t= whenever there are bound commands that can be autoloaded (e.g. it will not imply =:defer t= if the only bound command is to a lambda, for example). Whenever autoloadable commands are bound, use-package will create autoloads for them (though this is usually not necessary). The keyword is followed by one or more lists containing arguments for ~general-def~; there is no difference in syntax:
+General also optionally provides a use-package keyword. =:general= is similar to =:bind= in that it implies =:defer t= whenever there are bound commands that can be autoloaded (e.g. it will not imply =:defer t= if the only bound command is to a lambda, for example). Whenever autoloadable commands are bound, and the option ~general-use-package-emit-autoloads~ is non-nil, use-package will create autoloads for them (though this is usually not necessary). The keyword is followed by one or more lists containing arguments for ~general-def~; there is no difference in syntax:
 #+begin_src emacs-lisp
 (use-package org
   :general
@@ -1008,6 +1008,30 @@ One annoyance you may encounter is that the default function for indentation wil
 #+end_src
 
 This is an annoyance you may have using other emacs packages as well and can be fixed by modifying =lisp-indent-function= (see [[http://emacs.stackexchange.com/q/10230/5278][this emacs stackexchange question]] and Fuco1's modified ~lisp-indent-function~ in one of the answers there).
+
+*** :no-autoload Keyword
+
+If generating autoloads for commands is not desirable, it can be disabled globally (with the ~general-use-package-emit-autoloads~ option), on a per-binding, or on a per-form basis. To skip generating autoloads for a command, use the extended command definition and set the =:no-autoload= option to non-nil. This can be particularly handy when binding to functions defined in the same use-package block, otherwise the byte-compiler complains about multiple definitions of the same function:
+#+begin_src emacs-lisp
+(use-package org
+  :general
+  (:states 'normal
+   "SPC oa" '(my-org-agenda :no-autoload t))
+  :preface
+  (defun my-org-agenda ()
+    (interactive)
+    (let ((org-agenda-tag-filter-preset '("-drill")))
+      (call-interactively #'org-agenda))))
+#+end_src
+
+The keyword can also be used at the global level, instructing general to skip autoloads for all the keybindings in a form:
+#+begin_src emacs-lisp
+:general
+(:states 'normal
+ :no-autoload t
+ "SPC oa" #'my-org-agenda
+ "SPC oc" #'my-org-capture)
+#+end_src
 
 *** Hook Keywords
 General provides two alternatives to =:hook= that use ~general-add-hook~ called =:ghook= and =:gfhook=. Both take any number of arguments of symbols or lists. List arguments work the same for both; they correspond to a list of arguments for [[#hooks-and-advice][~general-add-hook~]]. The primary difference between the two is that symbol arguments to =:ghook= are /hooks/, but they are /functions/ for =:gfhook= (hence the =f=). Furthermore, =:ghook= usually implies =:defer t=, and =:gfhook= never implies =:defer t=. =:ghook= should be used when the ~general-add-hook~ is meant to trigger the loading of the package. =:gfhook= should be used when the ~general-add-hook~ is meant to trigger some function in response to the package's mode being enabled (or toggled in the case of a minor mode). More simply put, =:ghook= is suited towards enabling minor modes, and =:gfhook= is suited towards performing setup once some mode has loaded. The use case for each is further explained below.

--- a/README.org
+++ b/README.org
@@ -1032,6 +1032,8 @@ The keyword can also be used at the global level, instructing general to skip au
  "SPC oc" #'my-org-capture)
 #+end_src
 
+If you wish to disable emitting autoloads with the =general-use-package-emit-autoloads= variable in a byte-compiled configuration, make sure it is set during macro-expansion time before the =use-package= declarations, with something like =(eval-when-compile (setq general-use-package-emit-autoloads nil))=.
+
 *** Hook Keywords
 General provides two alternatives to =:hook= that use ~general-add-hook~ called =:ghook= and =:gfhook=. Both take any number of arguments of symbols or lists. List arguments work the same for both; they correspond to a list of arguments for [[#hooks-and-advice][~general-add-hook~]]. The primary difference between the two is that symbol arguments to =:ghook= are /hooks/, but they are /functions/ for =:gfhook= (hence the =f=). Furthermore, =:ghook= usually implies =:defer t=, and =:gfhook= never implies =:defer t=. =:ghook= should be used when the ~general-add-hook~ is meant to trigger the loading of the package. =:gfhook= should be used when the ~general-add-hook~ is meant to trigger some function in response to the package's mode being enabled (or toggled in the case of a minor mode). More simply put, =:ghook= is suited towards enabling minor modes, and =:gfhook= is suited towards performing setup once some mode has loaded. The use case for each is further explained below.
 

--- a/general.el
+++ b/general.el
@@ -317,6 +317,15 @@ should either set it using customize (e.g. `general-setq' or
   :type '(repeat general-state)
   :set #'general-override-make-intercept-maps)
 
+(defcustom general-use-package-emit-autoloads t
+  "Whether the `use-package' integration should autoload bound commands.
+By default, any command bound in the `:general' section of `use-package'
+is added to the list of autoloaded commands.
+Setting this variable to nil prevents such behavior.
+Also see the documentation of the `:no-autoload' keyword argument."
+  :group 'general
+  :type 'boolean)
+
 (defun general--update-maps-alist ()
   "Update `general-maps-alist' for override modes.
 This is necessary to ensure `general-override-local-mode-map' is the buffer's
@@ -2598,8 +2607,9 @@ return nil."
   (defun use-package-autoloads/:general (_name _keyword args)
     "Return an alist of commands extracted from ARGS.
 Return something like '((some-command-to-autoload . command) ...)."
-    (mapcar (lambda (command) (cons command 'command))
-            (plist-get args :commands)))
+    (and general-use-package-emit-autoloads
+         (mapcar (lambda (command) (cons command 'command))
+                 (plist-get args :commands))))
 
   (defun use-package-handler/:general (name _keyword args rest state)
     "Use-package handler for :general."

--- a/general.el
+++ b/general.el
@@ -2535,10 +2535,14 @@ return nil."
   ;; explicit null checks not required because nil return value means no def
   (when (general--extended-def-p def)
     ;; extract definition
-    (let ((first (car def)))
-      (setq def (if (keywordp first)
-                    (plist-get def :def)
-                  first))))
+    (let* ((first (car def))
+           (is-plist (keywordp first))
+           (arg-plist (if is-plist def (cdr def)))
+           (should-autoload (not (plist-get arg-plist :no-autoload))))
+      (setq def (when should-autoload
+                  (if is-plist
+                      (plist-get arg-plist :def)
+                    first)))))
   (cond ((symbolp def)
          def)
         ((and (consp def)

--- a/general.el
+++ b/general.el
@@ -2584,21 +2584,23 @@ return nil."
             ;; positional arguments
             (cl-loop for arglist in general-arglists
                      append (general--sanitize-arglist arglist)))
+           (should-autoload (not (plist-get sanitized-arglist :no-autoload)))
            (commands
-            (cl-loop for (key def) on sanitized-arglist by 'cddr
-                     when (and (not (keywordp key))
-                               (not (null def))
-                               (ignore-errors
-                                 ;; remove extra quote
-                                 ;; `eval' works in some cases that `cadr' does
-                                 ;; not (e.g. quoted string, '(list ...), etc.)
-                                 ;; `ignore-errors' handles cases where it fails
-                                 ;; (e.g. variable not defined at
-                                 ;; macro-expansion time)
-                                 (setq def (eval def))
-                                 (setq def (general--extract-autoloadable-symbol
-                                            def))))
-                     collect def)))
+            (and should-autoload
+                 (cl-loop for (key def) on sanitized-arglist by 'cddr
+                          when (and (not (keywordp key))
+                                    (not (null def))
+                                    (ignore-errors
+                                      ;; remove extra quote
+                                      ;; `eval' works in some cases that `cadr' does
+                                      ;; not (e.g. quoted string, '(list ...), etc.)
+                                      ;; `ignore-errors' handles cases where it fails
+                                      ;; (e.g. variable not defined at
+                                      ;; macro-expansion time)
+                                      (setq def (eval def))
+                                      (setq def (general--extract-autoloadable-symbol
+                                                 def))))
+                          collect def))))
       (list :arglists general-arglists :commands commands)))
 
   (defun use-package-autoloads/:general (_name _keyword args)

--- a/general.el
+++ b/general.el
@@ -2588,7 +2588,7 @@ or the `:no-autoload' keyword argument is non-nil, return nil."
   ;; altered args will be passed to the autoloads and handler functions
   (defun use-package-normalize/:general (_name _keyword general-arglists)
     "Return a plist containing the original ARGLISTS and autoloadable symbols."
-    (let* ((commands
+    (let ((commands
             (cl-loop for arglist in general-arglists
                      for sanitized = (general--sanitize-arglist arglist)
                      unless (plist-get sanitized :no-autoload)
@@ -2598,6 +2598,12 @@ or the `:no-autoload' keyword argument is non-nil, return nil."
                       when (and (not (keywordp key))
                                 (not (null def))
                                 (ignore-errors
+                                  ;; remove extra quote
+                                  ;; `eval' works in some cases that `cadr' does
+                                  ;; not (e.g. quoted string, '(list ...), etc.)
+                                  ;; `ignore-errors' handles cases where it fails
+                                  ;; (e.g. variable not defined at
+                                  ;; macro-expansion time)
                                   (setq def (eval def))
                                   (setq def (general--extract-autoloadable-symbol
                                              def))))

--- a/general.el
+++ b/general.el
@@ -322,6 +322,11 @@ should either set it using customize (e.g. `general-setq' or
 By default, any command bound in the `:general' section of `use-package'
 is added to the list of autoloaded commands.
 Setting this variable to nil prevents such behavior.
+
+Note that if your configuration is byte-compiled, this variable needs
+to be set at macro-expansion time, with `eval-when-compile'
+or `eval-and-compile', before the `use-package' declarations.
+
 Also see the documentation of the `:no-autoload' keyword argument."
   :group 'general
   :type 'boolean)

--- a/general.el
+++ b/general.el
@@ -2540,7 +2540,7 @@ aliases such as `nmap' for `general-nmap'."
 This will also correctly extract the definition from a cons of the form (STRING
 . DEFN). If the extracted definition is nil, a string, a lambda, a keymap symbol
 from an extended definition, or some other definition that cannot be autoloaded,
-return nil."
+or the `:no-autoload' keyword argument is non-nil, return nil."
   ;; explicit null checks not required because nil return value means no def
   (when (general--extended-def-p def)
     ;; extract definition


### PR DESCRIPTION
This PR adds the custom variable `general-use-package-emit-autoloads` to disable emitting autoloads, and the global and local keyword argument `:no-autoload`, which suppresses autoloading all commands from a form or just one of them, respectively.

I don't think this functionality can be implemented with the extensible keyword argument handling system, so it's baked-in into the use-package integration (but please correct me if I'm wrong).

Also, if you know more `cl-loop`-fu than I do, and you can come up with a way to write less ugly nested loops, please hit me up 😃.

Fixes #489