### PR TITLE
Add replace to general-non-normal-states

### DIFF
--- a/general.el
+++ b/general.el
@@ -112,7 +112,7 @@ Non-evil users should keep this nil."
                         "This functionality will be removed in the future."
                         "2018-01-21")
 
-(defcustom general-non-normal-states '(insert emacs hybrid iedit-insert)
+(defcustom general-non-normal-states '(insert replace emacs hybrid iedit-insert)
   "List of \"non-normal\" evil states (used with :non-normal-prefix). When
   :states is not specified (only :keymaps), these will automatically be expanded
   to their full global evil keymap equivalents."


### PR DESCRIPTION
The default value of `general-non-normal-states` doesn't include `replace`.

Shouldn't Evil's replace-state be considered a non-normal state? Or is it an intentional omission?

This PR is a small addition to the default value.


