### PR TITLE
Allow 'general--print-map' to print keymaps as commands

### DIFF
--- a/general.el
+++ b/general.el
@@ -1507,10 +1507,14 @@ If X and Y are conses, the first element will be compared. Ordering is based on
 (defun general--print-map (map)
   "Print the keybinding MAP."
   (cl-destructuring-bind (key command previous) map
-    (princ (format "|=%.50s=|~%.50s~|~%.50s~|\n"
-                   (replace-regexp-in-string "|" "¦" (key-description key))
-                   command
-                   previous))))
+    (princ (concat
+            (replace-regexp-in-string
+             "\n" ""
+             (format "|=%.50s=|~%.50s~|~%.50s~|"
+                     (replace-regexp-in-string "|" "¦" (key-description key))
+                     command
+                     previous))
+            "\n"))))
 
 (defun general--print-maps-table (maps)
   "Print an org table for MAPS."


### PR DESCRIPTION
The current implementation of `general--print-map` sometimes prints broken Org Tables for me:

```org
| key         | command                    | previous |
|-------------+----------------------------+----------|
| =SPC ?=     | ~which-key-show-top-level~ | ~nil~    |
| =SPC E=     | ~eval-expression~          | ~nil~    |
| =SPC SPC=   | ~nil~                      | ~nil~    |
| =SPC SPC x= | ~(keymap #^[nil nil keymap |          |
#^^[3 0 pop-global-mark ~|~2~|
|=SPC a=|~nil~|~nil~|
|=M-u=|~universal-argument~|~nil~|
|=SPC P=|~nil~|~nil~|
|=SPC P s=|~profiler-start~|~2~|
|=SPC P e=|~profiler-stop~|~2~|
```

Because the command in the 4th row has a linebreak.

This change removes unnecessary linebreaks from the result of the format expression, so that the case above works correctly.

```
| key           | command                                              | previous                                             |
|---------------+------------------------------------------------------+------------------------------------------------------|
| =SPC ?=       | ~which-key-show-top-level~                           | ~nil~                                                |
| =SPC E=       | ~eval-expression~                                    | ~nil~                                                |
| =SPC SPC=     | ~nil~                                                | ~nil~                                                |
| =SPC SPC x=   | ~(keymap #^[nil nil keymap #^^[3 0 pop-global-mark ~ | ~2~                                                  |
| =SPC a=       | ~nil~                                                | ~nil~                                                |
| =M-u=         | ~universal-argument~                                 | ~nil~                                                |
| =SPC P=       | ~nil~                                                | ~nil~                                                |
| =SPC P s=     | ~profiler-start~                                     | ~2~                                                  |
| =SPC P e=     | ~profiler-stop~                                      | ~2~                                                  |
```