### PR TITLE
Add basic sanity checks in general-unbind-non-prefix-key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
       - '**.el'
       - '**test.yml'
   push:
+    branches:
+      - main
     paths:
       - '**.el'
       - '**test.yml'
@@ -19,7 +21,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         # no 24.4 or 24.5 since some optional dependencies require higher
         # versions
-        emacs_version: [25.3, 26.3]
+        emacs_version: [28.2, 29.3]
         # emacs_version: [25.3, 26.3, snapshot]
         # include:
         #   - emacs_version: snapshot

--- a/Makefile
+++ b/Makefile
@@ -5,19 +5,19 @@ SANDBOX_DIR ?= ./sandbox
 deps:
 	@mkdir -p "$(SANDBOX_DIR)"
 	./with-gnu-utils/with-gnu-utils \
-		./makem/makem.sh -vv -S "$(SANDBOX_DIR)" \
+		./makem/makem.sh -vv --sandbox="$(SANDBOX_DIR)" \
 			--install-deps --install-linters
 
 .PHONY: test
 test:
 	@echo "Using $(shell which $(EMACS))..."
 	./with-gnu-utils/with-gnu-utils \
-		./makem/makem.sh -vv -S "$(SANDBOX_DIR)" test
+		./makem/makem.sh -vv --no-compile --sandbox="$(SANDBOX_DIR)" test
 
 .PHONY: lint
 lint:
 	./with-gnu-utils/with-gnu-utils \
-		./makem/makem.sh -vv -S "$(SANDBOX_DIR)" lint
+		./makem/makem.sh -vv --sandbox="$(SANDBOX_DIR)" lint
 
 .PHONY: clean
 clean:

--- a/general.el
+++ b/general.el
@@ -2255,9 +2255,11 @@ with `general-translate-key') and optionally keyword arguments for
 ;; ** Automatic Key Unbinding
 (defun general-unbind-non-prefix-key (define-key keymap key &rest args)
   "Use DEFINE-KEY in KEYMAP to unbind an existing non-prefix subsequence of KEY.
-When a general key definer is in use and a subsequnece of KEY is already bound
+When a general key definer is in use and a subsequence of KEY is already bound
 in KEYMAP, unbind it using DEFINE-KEY. Always bind KEY to DEF using DEFINE-KEY."
-  (when general--definer-p
+  (when (and general--definer-p
+             (keymapp keymap)
+             (arrayp key))
     (let ((key (if (stringp key)
                    (string-to-vector key)
                  key)))

--- a/tests/test-general.el
+++ b/tests/test-general.el
@@ -647,6 +647,7 @@ Return t if successful or a cons corresponding to the failed key and def."
         (expect (evil-get-command-properties 'general-should-repeat-and-jump)
                 :to-be nil))))
   (it "should support delaying keybindings until the keymap exists"
+    (expect (not (featurep 'general-delay)))
     (general-define-key
      :keymaps 'general-delay-map
      "a" #'a)


### PR DESCRIPTION
Saw it failing when keymap was nil.  Should do nothing in that case and not fail prematurely.